### PR TITLE
Add timeout support for UPPAAL verification commands

### DIFF
--- a/src/pyuppaal/umodel.py
+++ b/src/pyuppaal/umodel.py
@@ -380,27 +380,29 @@ system Process;
     # endregion 基础的文件保存功能
 
     # region 验证相关
-    def verify(self, trace_path: str = None, verify_options: str = None, keep_tmp_file: bool = True) -> str:
+    def verify(self, trace_path: str = None, verify_options: str = None, keep_tmp_file: bool = True, timeout: float = None) -> str:
         """Verify and return the verify result. If `trace_path` is not given, it wll return the terminal result.
 
         Args:
             trace_path (str, optional): the path to save the trace file. Defaults to None.
             verify_options (str, optional): options for verifyta, such as ` -t 0 -o 0`. Defaults to None.
             keep_tmp_file (bool, optional): whether to keep the temp file such as `xtr` or in-process `xml`. Defaults to True.
+            timeout (float, optional): timeout in seconds for the verification command execution.
 
         Returns:
             str: terminal verify results for `self`.
         """
-        return Verifyta().verify(self.model_path, trace_path, verify_options, keep_tmp_file)
+        return Verifyta().verify(self.model_path, trace_path, verify_options, keep_tmp_file, timeout=timeout)
 
     def easy_verify(
-        self, verify_options: str = "-t 1", keep_tmp_file=True
+        self, verify_options: str = "-t 1", keep_tmp_file=True, timeout: float = None
     ) -> SimTrace | None:
         """Easily verify current model, create a `.xtr` trace file that has the same name as `self.model_path`, and return parsed counter example as `SimTrace` (if exists). You can do easy_verify with only ONE query each time.
 
         Args:
             verify_options (str, optional): verify options, and `-t` must be set because returning a `SimTrace` requires a `.xtr` trace file. Defaults to '-t 1', returning the shortest trace.
             keep_tmp_file (bool, optional): whether to keep the temp file such as `xtr` or in-process `xml`. Defaults to True.
+            timeout (float, optional): timeout in seconds for the verification command execution.
 
         Returns:
             SimTrace | None: if exists a counter example, return a SimTrace, else return None.
@@ -417,7 +419,7 @@ system Process;
         if Verifyta().get_uppaal_version() == 4:  # uppaal4.x
             xtr_trace_path = self.model_path.replace(".xml", ".xtr")
             verify_cmd_res = Verifyta().verify(
-                self.model_path, xtr_trace_path, verify_options=verify_options
+                self.model_path, xtr_trace_path, verify_options=verify_options, timeout=timeout
             )
 
             # print(verify_cmd_res)
@@ -430,7 +432,7 @@ system Process;
         else:  # uppaal5.x
             xtr_trace_path = self.model_path.replace(".xml", "_xtr")
             verify_cmd_res = Verifyta().verify(
-                self.model_path, xtr_trace_path, verify_options=verify_options
+                self.model_path, xtr_trace_path, verify_options=verify_options, timeout=timeout
             )
 
             xtr_trace_path = xtr_trace_path.replace("_xtr", "_xtr-1")

--- a/src/pyuppaal/verifyta.py
+++ b/src/pyuppaal/verifyta.py
@@ -27,9 +27,9 @@ class Verifyta:
             return
         self.__is_first_init = False
 
-        self.__verifyta_path: str | None = None
+        self.__verifyta_path: str = None
 
-        self.__verifyta_version: int | None = None
+        self.__verifyta_version: int = None
 
         self.__operating_system: str = self.get_env()
 
@@ -40,7 +40,7 @@ class Verifyta:
         Returns:
             str: current verifyta path.
         """
-        return self.__verifyta_path or ""
+        return self.__verifyta_path
 
     @staticmethod
     def get_env() -> str:  # operation system
@@ -113,12 +113,12 @@ class Verifyta:
             raise ValueError(
                 f"Invalid verifyta_path: {verifyta_path}.\n{example_info} \nVerifyta Not Found!.")
 
-    def cmd(self, cmd: str, timeout: float | None = None) -> str:
+    def cmd(self, cmd: str, timeout: float = None) -> str:
         """Run common command with cmd, you can easily ignore the verifyta path.
 
         Args:
             cmd (str): command to run.
-            timeout (float | None): timeout in seconds for the command execution.
+            timeout (float, optional): timeout in seconds for the command execution.
 
         Raises:
             ValueError: if verifyta_path is not set.
@@ -225,7 +225,7 @@ class Verifyta:
 
         return if_path
 
-    def verify(self, model_path: str, trace_path: str | None = None, verify_options: str = "-t 1", keep_tmp_file=True, timeout: float | None = None) -> str:
+    def verify(self, model_path: str, trace_path: str = None, verify_options: str = "-t 1", keep_tmp_file=True, timeout: float = None) -> str:
         """
         Verify model and return the verify result as list.
         This is designed for advanced UPPAAL user.
@@ -248,7 +248,7 @@ class Verifyta:
             verify_options (str, optional): verify options that are proveded by `verifyta`, and you can get details by run `verifyta -h` in your terminal.
                 Defaults to '-t 1', returning the shortest trace.
             keep_tmp_file (bool, optional): whether to keep temporary trace files. Defaults to True.
-            timeout (Optional[float], optional): timeout in seconds for the verification command execution.
+            timeout (float, optional): timeout in seconds for the verification command execution.
 
         Raises:
             ValueError: if tracer file is not `xml` or `xtr`.

--- a/src/pyuppaal/verifyta.py
+++ b/src/pyuppaal/verifyta.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import platform
 import os
 import subprocess
-from typing import List
 
 
 class Verifyta:
@@ -28,9 +27,9 @@ class Verifyta:
             return
         self.__is_first_init = False
 
-        self.__verifyta_path: str = None
+        self.__verifyta_path: str | None = None
 
-        self.__verifyta_version: int = None
+        self.__verifyta_version: int | None = None
 
         self.__operating_system: str = self.get_env()
 
@@ -41,7 +40,7 @@ class Verifyta:
         Returns:
             str: current verifyta path.
         """
-        return self.__verifyta_path
+        return self.__verifyta_path or ""
 
     @staticmethod
     def get_env() -> str:  # operation system
@@ -221,7 +220,7 @@ class Verifyta:
 
         return if_path
 
-    def verify(self, model_path: str, trace_path: str = None, verify_options: str = "-t 1", keep_tmp_file=True) -> str:
+    def verify(self, model_path: str, trace_path: str | None = None, verify_options: str = "-t 1", keep_tmp_file=True) -> str:
         """
         Verify model and return the verify result as list.
         This is designed for advanced UPPAAL user.

--- a/src/pyuppaal/verifyta.py
+++ b/src/pyuppaal/verifyta.py
@@ -113,15 +113,17 @@ class Verifyta:
             raise ValueError(
                 f"Invalid verifyta_path: {verifyta_path}.\n{example_info} \nVerifyta Not Found!.")
 
-    def cmd(self, cmd: str) -> str:
+    def cmd(self, cmd: str, timeout: float | None = None) -> str:
         """Run common command with cmd, you can easily ignore the verifyta path.
 
         Args:
             cmd (str): command to run.
+            timeout (float | None): timeout in seconds for the command execution.
 
         Raises:
             ValueError: if verifyta_path is not set.
             ValueError: if cmd got stderr and not as expected.
+            TimeoutError: if command execution times out.
 
         Returns:
             str: the output of the input command.
@@ -134,7 +136,10 @@ class Verifyta:
 
         # Run the command and check for errors. Use shell because we set env var and && is used.
         # macos and windows use shell, linux not use
-        cmd_res = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=False)
+        try:
+            cmd_res = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=False, timeout=timeout)
+        except subprocess.TimeoutExpired as e:
+            raise TimeoutError(f"Command '{cmd}' timed out after {timeout} seconds") from e
 
         if cmd_res.stderr is not None and cmd_res.stderr != '':
             if "Writing example trace to" in cmd_res.stderr:
@@ -220,7 +225,7 @@ class Verifyta:
 
         return if_path
 
-    def verify(self, model_path: str, trace_path: str | None = None, verify_options: str = "-t 1", keep_tmp_file=True) -> str:
+    def verify(self, model_path: str, trace_path: str | None = None, verify_options: str = "-t 1", keep_tmp_file=True, timeout: float | None = None) -> str:
         """
         Verify model and return the verify result as list.
         This is designed for advanced UPPAAL user.
@@ -242,9 +247,12 @@ class Verifyta:
                 Defaults to None, which will create `.xtr` path.
             verify_options (str, optional): verify options that are proveded by `verifyta`, and you can get details by run `verifyta -h` in your terminal.
                 Defaults to '-t 1', returning the shortest trace.
+            keep_tmp_file (bool, optional): whether to keep temporary trace files. Defaults to True.
+            timeout (Optional[float], optional): timeout in seconds for the verification command execution.
 
         Raises:
             ValueError: if tracer file is not `xml` or `xtr`.
+            TimeoutError: if verification command times out.
 
         Returns:
             str: terminal verify results for `.xml` model.
@@ -299,7 +307,7 @@ class Verifyta:
 
         # 构造命令
         cmd = f'{cmd_env}&&{self.__verifyta_path} {model_path} {option}'
-        res = self.cmd(cmd)
+        res = self.cmd(cmd, timeout=timeout)
 
         # remove tmp file
         if not keep_tmp_file:


### PR DESCRIPTION
Summary

- Add optional timeout parameter to verification methods in verifyta.py and umodel.py
- Raise `TimeoutError` when timeout is exceeded, allowing proper handling of long running queries
- Maintain backward compatibility by making timeout parameter optional

Changes

- verifyta.py: Add optional `timeout` parameter to `cmd()` and `verify()`, handle timeout with `subprocess.run(..., timeout=)` option, raise `TimeoutError` on timeout expiration
- umodel.py: Add optional `timeout` argument to `verify()` and `easy_verify()` methods
